### PR TITLE
Use hooks and fix integration with registration form

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "raf": "3.4.1",
     "react": "^16.8.6",
     "react-apollo": "^2.5.8",
-    "react-apollo-hooks": "^0.4.5",
+    "react-apollo-hooks": "^0.5.0",
     "react-big-calendar": "0.22.0",
     "react-bootstrap-sweetalert": "4.4.1",
     "react-chartist": "0.13.3",

--- a/src/components/RegisterForm/index.jsx
+++ b/src/components/RegisterForm/index.jsx
@@ -13,7 +13,7 @@ const RegisterForm = ({
   password,
   firstName,
   lastName,
-  organization,
+  orgName,
   agreeTOS
 }) => {
   return (
@@ -29,7 +29,7 @@ const RegisterForm = ({
         value={email}
         fullWidth
         autoComplete="email"
-        onChange={handleChange}
+        onChange={handleChange("email")}
       />
       <TextField
         required
@@ -39,7 +39,7 @@ const RegisterForm = ({
         value={firstName}
         fullWidth
         autoComplete="fname"
-        onChange={handleChange}
+        onChange={handleChange("firstName")}
       />
       <TextField
         required
@@ -49,17 +49,17 @@ const RegisterForm = ({
         value={lastName}
         fullWidth
         autoComplete="lname"
-        onChange={handleChange}
+        onChange={handleChange("lastName")}
       />
       <TextField
         required
-        id="organization"
-        name="organization"
+        id="orgName"
+        name="orgName"
         label="Organization"
-        value={organization}
+        value={orgName}
         fullWidth
-        autoComplete="organization"
-        onChange={handleChange}
+        autoComplete="orgName"
+        onChange={handleChange("orgName")}
       />
       <TextField
         id="password"
@@ -69,7 +69,7 @@ const RegisterForm = ({
         name="password"
         fullWidth
         value={password}
-        onChange={handleChange}
+        onChange={handleChange("password")}
         autoComplete="current-password"
       />
       <FormControlLabel
@@ -77,7 +77,7 @@ const RegisterForm = ({
           <Checkbox
             color="secondary"
             required
-            onChange={handleChange}
+            onChange={handleChange("agreeTOS")}
             name="agreeTOS"
             checked={agreeTOS}
             value="yes"
@@ -94,7 +94,7 @@ RegisterForm.propTypes = {
   email: PropTypes.string.isRequired,
   firstName: PropTypes.string.isRequired,
   lastName: PropTypes.string.isRequired,
-  organization: PropTypes.string.isRequired,
+  orgName: PropTypes.string.isRequired,
   password: PropTypes.string.isRequired,
   agreeTOS: PropTypes.bool.isRequired
 };

--- a/src/pages/Register/index.jsx
+++ b/src/pages/Register/index.jsx
@@ -54,12 +54,16 @@ function Register({ history }) {
       } else {
         localStorage.setItem("token", token);
         setLoading(false);
+        history.push("/recipes");
+        /*
+        // Modals aren't working! You can use this flow to get a success view though.
         setAlert({
           alert: {
             type: "createSuccess",
             message: "Successfully created your user. Welcome!"
           }
         });
+        */
       }
     }
   });
@@ -67,12 +71,21 @@ function Register({ history }) {
   const onComplete = async () => {
     setLoading(true);
     await registerUser();
-    history.push("/recipes");
   };
 
-  if (!_.isEmpty(alert)) {
+  if (!_.isEmpty(alert) && alert.type == "Modal's don't work for now!?") {
     // we weren't handling alerts before so this will do for now.
-    return <Modal message={alert.message} handleClose={() => setAlert({})} />;
+    return (
+      <Modal
+        message={alert.message}
+        handleClose={() => {
+          setAlert({});
+          if (alert.type == "createSuccess") {
+            history.push("/recipes");
+          }
+        }}
+      />
+    );
   }
 
   if (loading) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9180,10 +9180,10 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-apollo-hooks@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/react-apollo-hooks/-/react-apollo-hooks-0.4.5.tgz#7fe6a8ddfdc92df2da664d399ea77a0da4a10bad"
-  integrity sha512-fq04h88hg4ONtlzxYInmv7Okqqstzk3UCp55jHWOlIO2lFKoZPhQrtCz7A+TrcRu8GGwtG1SsioRKN8kIQaAOQ==
+react-apollo-hooks@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/react-apollo-hooks/-/react-apollo-hooks-0.5.0.tgz#49607fbe9cdfd0be08ea5defd39085bf5f42e10e"
+  integrity sha512-Us5KqFe7/c6vY1NaiyfhnD2Pz4lPLTojQXLppShaBVYU/vYvJrRjmj4MzIPXnExXaSfnQ+K2bWDr4lP4efbsRQ==
   dependencies:
     lodash "^4.17.11"
 


### PR DESCRIPTION
This resolves some important issues I've identified with the registration form:

1) The `$orgName` variable was not being passed to the GraphQL mutation, because the registration form was using `organization` instead of `orgName`. If you want to keep `organization`, you'll want to map the variables appropriately. I discovered this was the source of the issue by opening the network tab and looking at the variables that were passed in the body of the request.

2) Using a monolithic state value is discouraged in modern versions of React. We should be using hooks for handling these kinds of flows. I've worked around some of the initial assumptions between the responsibilities of the registration from and registration page by implementing a `handleChange` approach somewhat similar to the reference implementations available in Material-UI for many fo their forms. 

3) We should not be directly interaction with the Apollo client. A better approach is to use the `withApollo` HOC to pass queries and mutations into the props of a component. A far more modern and forward-looking approach is to implement the hooks in `react-apollo-hooks` which are about to go GA into the normal `react-apollo` library. I've implemented the `useMutation` query here the same way we're using `useQuery` for the `HealthQuery` in the the `App` component.   I've worked around the general weirdness of using the Wizard to control the flow of behavior by using effects as well. 

As we move forward to integrating GraphQL to these very nice-looking components, let's please take every effort to use React and Apollo's support for hooks, since this is the direction that the React community is taking for maintaining events and state changes.